### PR TITLE
Frontend/like handling

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -173,9 +173,9 @@ app.get(
   }
 );
 
+// returns only a list of liked posts UUIDs, nothing more
 app.get("/fetch_likes/:useruuid", async (req, res) => {
   // likes are public by default, no auth necessary!
-  // returns only a list of liked posts, nothing more
   const { useruuid } = req.params;
 
   try {
@@ -197,7 +197,7 @@ app.get("/fetch_likes/:useruuid", async (req, res) => {
 // so each user can have a like-page with all their liked posts!
 app.get("/fetch_likes_posts/:useruuid", async (req, res) => {
   // likes are public by default, no auth necessary!
-  // returns only a list of liked posts, nothing more
+
   const { useruuid } = req.params;
 
   try {

--- a/backend/app.js
+++ b/backend/app.js
@@ -43,7 +43,7 @@ app.put("/update_user", authJwt.verifyToken, async (req, res) => {
       password: bcrypt.hashSync(password),
       email,
     });
-      return res.json(dbUser);
+    return res.json(dbUser);
   } catch (err) {
     console.log(err);
     return res.status(500).json({ error: err });

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -44,6 +44,21 @@ body {
   padding: var(--padding-mobile);
 }
 
+/* Button styling which is not visible as a button but only as its contained text item */
+.button-nooutline {
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  text-decoration: underline;
+  display: inline;
+  margin: 0;
+  padding: 0;
+}
+
+.hidden {
+  display: none;
+}
+
 @media all and (min-width: 930px) {
   .page {
     padding: var(--padding-desktop-above) var(--padding-desktop-leftright);

--- a/frontend/src/Pages/PostDetail.jsx
+++ b/frontend/src/Pages/PostDetail.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import classes from "./PostDetails.module.css";
 import signUpClasses from "../Pages/SignUp.module.css";
@@ -6,9 +6,11 @@ import Axios from "axios";
 import Card from "../UI/Card";
 import Button from "../UI/Button";
 import AuthContext from "../store/auth-context";
+import LikeContext from "../store/like-context";
+import singleOfferClasses from "../partials/SingleOffer.module.css";
 
 import { FaTimes } from "react-icons/fa";
-import { useContext } from "react";
+import { AiFillStar, AiOutlineStar } from "react-icons/ai";
 
 const PostDetail = () => {
   const [singlePost, updateSinglePost] = useState({
@@ -17,10 +19,22 @@ const PostDetail = () => {
   });
   const [errMsg, updateErrMsg] = useState();
   const [showEditButton, updateShowEditButton] = useState(false);
+  const [postLiked, setPostLiked] = useState(false);
 
   const { id } = useParams();
   const authCtx = useContext(AuthContext);
+  const likeCtx = useContext(LikeContext);
   const navigate = useNavigate();
+
+  // toggles which star symbol is shown
+  // when "postLiked" is true, then the star outline will be filled
+  useEffect(() => {
+    if (likeCtx.likes.includes(singlePost.uuid) && authCtx.isLoggedIn) {
+      setPostLiked(true);
+    } else {
+      setPostLiked(false);
+    }
+  }, [singlePost.uuid, likeCtx.likes, authCtx.isLoggedIn]);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -37,11 +51,31 @@ const PostDetail = () => {
     fetchData();
   }, [id]);
 
+  // handles the deletion of posts. When a post is deleted successfully,
+  // the user gets navigated to the front page
+  const handleDeletePost = async () => {
+    try {
+      await Axios.delete(
+        `http://localhost:3307/delete_post/${singlePost.uuid}`,
+        {
+          headers: { "x-access-token": authCtx.auth.accessToken },
+        }
+      );
+      navigate("/");
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
   useEffect(() => {
     if (authCtx.isLoggedIn && singlePost.user.uuid === authCtx.auth.uuid) {
       updateShowEditButton(true);
-    }
+    } else updateShowEditButton(false);
   }, [singlePost, authCtx]);
+
+  const handleLike = () => {
+    likeCtx.toggleLike(singlePost.uuid);
+  };
 
   return (
     <Card>
@@ -61,6 +95,16 @@ const PostDetail = () => {
             {singlePost.user.username}
           </Link>
         </p>
+        <div className={singleOfferClasses.favorite}>
+          <button
+            onClick={handleLike}
+            className={`${classes["star-button"]} ${
+              !authCtx.isLoggedIn && "hidden"
+            } button-nooutline`}
+          >
+            {postLiked ? <AiFillStar /> : <AiOutlineStar />}
+          </button>
+        </div>
         {showEditButton && (
           <Button
             onClick={() => {
@@ -70,6 +114,15 @@ const PostDetail = () => {
             className="color-two"
           >
             Edit Offer
+          </Button>
+        )}{" "}
+        {showEditButton && (
+          <Button
+            onClick={handleDeletePost}
+            variant="contained"
+            className="color-three"
+          >
+            Delete Offer
           </Button>
         )}
       </div>

--- a/frontend/src/Pages/PostDetail.jsx
+++ b/frontend/src/Pages/PostDetail.jsx
@@ -10,7 +10,12 @@ import LikeContext from "../store/like-context";
 import singleOfferClasses from "../partials/SingleOffer.module.css";
 
 import { FaTimes } from "react-icons/fa";
-import { AiFillStar, AiOutlineStar } from "react-icons/ai";
+import {
+  AiFillStar,
+  AiOutlineStar,
+  AiFillDelete,
+  AiFillEdit,
+} from "react-icons/ai";
 
 const PostDetail = () => {
   const [singlePost, updateSinglePost] = useState({
@@ -95,36 +100,38 @@ const PostDetail = () => {
             {singlePost.user.username}
           </Link>
         </p>
-        <div className={singleOfferClasses.favorite}>
-          <button
-            onClick={handleLike}
-            className={`${classes["star-button"]} ${
-              !authCtx.isLoggedIn && "hidden"
-            } button-nooutline`}
-          >
-            {postLiked ? <AiFillStar /> : <AiOutlineStar />}
-          </button>
+        <div className={classes.icons}>
+          {!showEditButton && (
+            <button
+              onClick={handleLike}
+              className={`${classes.icon} ${
+                !authCtx.isLoggedIn && "hidden"
+              } button-nooutline`}
+            >
+              {postLiked ? <AiFillStar /> : <AiOutlineStar />}
+            </button>
+          )}
+          {showEditButton && (
+            <button
+              onClick={() => {
+                navigate(`/offer/edit/${singlePost.uuid}`);
+              }}
+              variant="contained"
+              className={`button-nooutline ${classes.icon}`}
+            >
+              <AiFillEdit />
+            </button>
+          )}{" "}
+          {showEditButton && (
+            <button
+              onClick={handleDeletePost}
+              variant="contained"
+              className={`button-nooutline ${classes.icon}`}
+            >
+              <AiFillDelete />
+            </button>
+          )}
         </div>
-        {showEditButton && (
-          <Button
-            onClick={() => {
-              navigate(`/offer/edit/${singlePost.uuid}`);
-            }}
-            variant="contained"
-            className="color-two"
-          >
-            Edit Offer
-          </Button>
-        )}{" "}
-        {showEditButton && (
-          <Button
-            onClick={handleDeletePost}
-            variant="contained"
-            className="color-three"
-          >
-            Delete Offer
-          </Button>
-        )}
       </div>
     </Card>
   );

--- a/frontend/src/Pages/PostDetail.jsx
+++ b/frontend/src/Pages/PostDetail.jsx
@@ -7,15 +7,9 @@ import Card from "../UI/Card";
 import Button from "../UI/Button";
 import AuthContext from "../store/auth-context";
 import LikeContext from "../store/like-context";
-import singleOfferClasses from "../partials/SingleOffer.module.css";
 
 import { FaTimes } from "react-icons/fa";
-import {
-  AiFillStar,
-  AiOutlineStar,
-  AiFillDelete,
-  AiFillEdit,
-} from "react-icons/ai";
+import { AiFillStar, AiOutlineStar } from "react-icons/ai";
 
 const PostDetail = () => {
   const [singlePost, updateSinglePost] = useState({
@@ -100,7 +94,7 @@ const PostDetail = () => {
             {singlePost.user.username}
           </Link>
         </p>
-        <div className={classes.icons}>
+        <div className={classes.interactions}>
           {!showEditButton && (
             <button
               onClick={handleLike}
@@ -112,24 +106,24 @@ const PostDetail = () => {
             </button>
           )}
           {showEditButton && (
-            <button
+            <Button
               onClick={() => {
                 navigate(`/offer/edit/${singlePost.uuid}`);
               }}
               variant="contained"
-              className={`button-nooutline ${classes.icon}`}
+              className="color-two"
             >
-              <AiFillEdit />
-            </button>
-          )}{" "}
+              Edit Offer
+            </Button>
+          )}
           {showEditButton && (
-            <button
+            <Button
               onClick={handleDeletePost}
               variant="contained"
-              className={`button-nooutline ${classes.icon}`}
+              className="color-three"
             >
-              <AiFillDelete />
-            </button>
+              Delete Offer
+            </Button>
           )}
         </div>
       </div>

--- a/frontend/src/Pages/PostDetails.module.css
+++ b/frontend/src/Pages/PostDetails.module.css
@@ -1,6 +1,16 @@
+.postDetail a {
+  text-decoration: none;
+  color: var(--color-three);
+  border-bottom: 1px solid var(--color-three);
+}
+
 .star-button {
   font-size: x-large;
   vertical-align: middle;
+}
+
+.interactions * {
+  margin: 0.5em 0.5em 0 0;
 }
 
 .icon {

--- a/frontend/src/Pages/PostDetails.module.css
+++ b/frontend/src/Pages/PostDetails.module.css
@@ -2,3 +2,7 @@
   font-size: x-large;
   vertical-align: middle;
 }
+
+.icon {
+  font-size: xx-large;
+}

--- a/frontend/src/Pages/PostDetails.module.css
+++ b/frontend/src/Pages/PostDetails.module.css
@@ -1,0 +1,4 @@
+.star-button {
+  font-size: x-large;
+  vertical-align: middle;
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -4,14 +4,17 @@ import { BrowserRouter as Router } from "react-router-dom";
 import "./index.css";
 import App from "./App";
 import { AuthContextProvider } from "./store/auth-context";
+import { LikeContextProvider } from "./store/like-context";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
     <AuthContextProvider>
-      <Router basename={`/${process.env.PUBLIC_URL}`}>
-        <App />
-      </Router>
+      <LikeContextProvider>
+        <Router basename={`/${process.env.PUBLIC_URL}`}>
+          <App />
+        </Router>
+      </LikeContextProvider>
     </AuthContextProvider>
   </React.StrictMode>
 );

--- a/frontend/src/partials/SingleOffer.jsx
+++ b/frontend/src/partials/SingleOffer.jsx
@@ -1,6 +1,12 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import classes from "./SingleOffer.module.css";
+import { AiFillStar, AiOutlineStar } from "react-icons/ai";
+import AuthContext from "../store/auth-context";
+import LikeContext from "../store/like-context";
+import { useContext } from "react";
+import { useEffect } from "react";
+import { useState } from "react";
 
 const truncate = (string, maxlength = 30, doTruncate = true) => {
   if (!doTruncate) {
@@ -12,6 +18,26 @@ const truncate = (string, maxlength = 30, doTruncate = true) => {
 };
 
 const SingleOffer = ({ item, className, doTruncate = true }) => {
+  const authCtx = useContext(AuthContext);
+  const likeCtx = useContext(LikeContext);
+  const [postLiked, setPostLiked] = useState(false);
+
+  const handleLike = () => {
+    likeCtx.toggleLike(item.uuid);
+  };
+
+  // checks if the "likes" list from the LikeContext contains the current posts UUID and if
+  // the user is currently logged in. When both conditions are met, the "postLiked"
+  // state is set to true which displays the filled star icon, otherwise the outline
+  // version of the star icon is shown.
+  useEffect(() => {
+    if (likeCtx.likes.includes(item.uuid) && authCtx.isLoggedIn) {
+      setPostLiked(true);
+    } else {
+      setPostLiked(false);
+    }
+  }, [item.uuid, likeCtx.likes, authCtx.isLoggedIn]);
+
   // console.log(item);
   return (
     <div className={`${classes.singleCard} ${className}`}>
@@ -25,6 +51,16 @@ const SingleOffer = ({ item, className, doTruncate = true }) => {
       {/* <span className={classes.points}>
           {item.points} {item.points > 1 ? "Points" : "Point"}
         </span> */}
+      <span className={classes.favorite}>
+        <button
+          onClick={handleLike}
+          className={`${classes["star-button"]} ${
+            !authCtx.isLoggedIn && "hidden"
+          } button-nooutline`}
+        >
+          {postLiked ? <AiFillStar /> : <AiOutlineStar />}
+        </button>
+      </span>
       <span className={classes.category}>
         {item.category && item.category.displayName}
       </span>

--- a/frontend/src/partials/SingleOffer.module.css
+++ b/frontend/src/partials/SingleOffer.module.css
@@ -26,3 +26,8 @@
   float: right;
   font-size: x-small;
 }
+
+.star-button {
+  color: white;
+  font-size: large;
+}

--- a/frontend/src/store/auth-context.jsx
+++ b/frontend/src/store/auth-context.jsx
@@ -4,7 +4,7 @@ const AuthContext = React.createContext({
   isLoggedIn: false,
   auth: {},
   onLogout: () => {},
-  onLogin: (email, password) => {},
+  onLogin: () => {},
 });
 
 export const AuthContextProvider = (props) => {
@@ -18,7 +18,7 @@ export const AuthContextProvider = (props) => {
     }
   }, []);
 
-  const loginFunction = (auth, email, password) => {
+  const loginFunction = (auth) => {
     // check email and password for validity on backend!
     setAuth(auth);
     localStorage.setItem("isLoggedIn", "1");

--- a/frontend/src/store/like-context.jsx
+++ b/frontend/src/store/like-context.jsx
@@ -1,0 +1,52 @@
+import React, { useState, useEffect, useContext } from "react";
+import AuthContext from "./auth-context";
+import Axios from "axios";
+
+const LikeContext = React.createContext({
+  likes: [],
+  toggleLike: (postuuid) => {},
+});
+
+export const LikeContextProvider = (props) => {
+  const authCtx = useContext(AuthContext);
+  const authAccessToken = authCtx.auth.accessToken;
+  const useruuid = authCtx.auth.uuid;
+  const [likes, setLikes] = useState([]);
+
+  const fetchLikes = async (useruuid) => {
+    if (useruuid) {
+      const res = await Axios.get(
+        `http://localhost:3307/fetch_likes/${useruuid}`
+      );
+      setLikes(res.data);
+    } else {
+      setLikes([]);
+    }
+  };
+
+  useEffect(() => {
+    fetchLikes(useruuid);
+  }, [useruuid]);
+
+  const likeFunction = async (postuuid) => {
+    const res = await Axios.get(
+      `http://localhost:3307/toggle_like_post/${postuuid}`,
+      { headers: { "x-access-token": authAccessToken } }
+    );
+    console.log(res.data);
+    fetchLikes(useruuid);
+  };
+
+  return (
+    <LikeContext.Provider
+      value={{
+        likes: likes,
+        toggleLike: likeFunction,
+      }}
+    >
+      {props.children}
+    </LikeContext.Provider>
+  );
+};
+
+export default LikeContext;

--- a/frontend/src/store/like-context.jsx
+++ b/frontend/src/store/like-context.jsx
@@ -35,10 +35,9 @@ export const LikeContextProvider = (props) => {
   }, [useruuid]);
 
   const likeFunction = async (postuuid) => {
-    const res = await Axios.get(
-      `http://localhost:3307/toggle_like_post/${postuuid}`,
-      { headers: { "x-access-token": authAccessToken } }
-    );
+    await Axios.get(`http://localhost:3307/toggle_like_post/${postuuid}`, {
+      headers: { "x-access-token": authAccessToken },
+    });
     fetchLikes(useruuid);
   };
 

--- a/frontend/src/store/like-context.jsx
+++ b/frontend/src/store/like-context.jsx
@@ -18,7 +18,13 @@ export const LikeContextProvider = (props) => {
       const res = await Axios.get(
         `http://localhost:3307/fetch_likes/${useruuid}`
       );
-      setLikes(res.data);
+      // unpack the likes returned from the backend. the likes from the backend are in JSON as follows:
+      // [{"postuuid": <postuuid0>}, {"postuuid": <postuuid1>}, {"postuuid": <postuuid2>}]
+      const likedPostsObjects = Object.values(res.data);
+      const likedPostsUuids = likedPostsObjects.map((item) => {
+        return item.postUUID;
+      });
+      setLikes(likedPostsUuids);
     } else {
       setLikes([]);
     }
@@ -33,7 +39,6 @@ export const LikeContextProvider = (props) => {
       `http://localhost:3307/toggle_like_post/${postuuid}`,
       { headers: { "x-access-token": authAccessToken } }
     );
-    console.log(res.data);
     fetchLikes(useruuid);
   };
 


### PR DESCRIPTION
Like handling works now both in the frontend as well as in the backend

Each post gets its own like button. The liked state is saved for each user in the backend in its own "likes" table and the likes are stored in a global context in the React Frontend, which minimizes calls to the backend to a minimum – only when the following actions are triggered, the backend gets fetched for likes:
- user logged in for the first time
- like created

See above for an image of the Like Buttons on the Home Page of the site:
![image](https://user-images.githubusercontent.com/1465851/186758207-fcbac3d4-c3a0-447f-bb10-9a17b66b6cfa.png)

If the user is not logged in, no Like Buttons are shown.
![image](https://user-images.githubusercontent.com/1465851/186758573-7fb8f2f2-5b52-4467-ae8c-6b5c5658d245.png)

The Single Offer Page now looks like this:
![image](https://user-images.githubusercontent.com/1465851/186758997-2cb49bcd-cd93-45f5-b29b-ee5143feb7b7.png)

Changes:
- added a Delete Button
- added a Like Button


